### PR TITLE
Fix toolbar icon

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -136,7 +136,7 @@ function addCommands(
   commands.addCommand(CommandIDs.newSpy, {
     label: 'New kernel spy',
     caption: 'Open a window to inspect messages sent to/from a kernel',
-    iconClass: 'jp-kernelspyIcon',
+    iconClass: 'jp-Icon jp-Icon-16 jp-kernelspyIcon',
     isEnabled: hasKernel,
     execute: (args) => {
       let current = tracker.currentWidget;


### PR DESCRIPTION
Looks like `jp-Icon` and `jp-Icon-16` are now needed for the latest JupyterLab.

### Before

![image](https://user-images.githubusercontent.com/591645/49331352-a8786a80-f59b-11e8-9ded-a83eb1874e0c.png)


### After

![image](https://user-images.githubusercontent.com/591645/49331345-8c74c900-f59b-11e8-9f32-f2872779f923.png)
