### PR TITLE
Open kernel spy panel on the right by default

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -145,7 +145,7 @@ function addCommands(
         return;
       }
       const widget = new KernelSpyView(current.context.session.kernel! as Kernel.IKernel);
-      shell.add(widget, 'main');
+      shell.add(widget, 'main', { mode: 'split-right' });
       if (args['activate'] !== false) {
         shell.activateById(widget.id);
       }


### PR DESCRIPTION
That might sound a bit opinionated, but it looks like opening the panel on the right would be a good default. 